### PR TITLE
Add `getLocale()` parameter to JavaScript Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.2.0 (IN PROGRESS)
+## 2.2.0 (2022-01-09)
 
 ### Features / Enhancements
 
@@ -12,6 +12,7 @@
 - Add JavaScript Code to add Handlebars helpers and Event handlers (#134)
 - Update default Content to `{{json @root}}` and Code Editor height to `200px` (#134)
 - Update CSS to fit images to screen (#135)
+- Add `getLocale()` parameter to JavaScript Code (#137)
 
 ## 2.1.0 (2022-11-27)
 

--- a/src/constants/editor.ts
+++ b/src/constants/editor.ts
@@ -47,6 +47,11 @@ export const CodeEditorSuggestions: CodeEditorSuggestionItem[] = [
   {
     label: 'handlebars',
     kind: CodeEditorSuggestionItemKind.Property,
-    detail: 'Handlebars object.',
+    detail: 'Handlebars library.',
+  },
+  {
+    label: 'getLocale',
+    kind: CodeEditorSuggestionItemKind.Method,
+    detail: 'Returns locale.',
   },
 ];

--- a/src/helpers/html.ts
+++ b/src/helpers/html.ts
@@ -1,6 +1,6 @@
 import Handlebars from 'handlebars';
 import MarkdownIt from 'markdown-it';
-import { textUtil } from '@grafana/data';
+import { getLocale, textUtil } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { registerHelpers } from './handlebars';
 
@@ -17,8 +17,8 @@ export const generateHtml = (data: Record<string, any>, content: string, helpers
    * Add Custom Helpers
    */
   if (helpers) {
-    const func = new Function('data', 'handlebars', helpers);
-    func(data, Handlebars, helpers);
+    const func = new Function('data', 'handlebars', 'getLocale', helpers);
+    func(data, Handlebars, getLocale, helpers);
   }
 
   /**


### PR DESCRIPTION
Resolves #110 

Content:

```handlebars
{{translate "Hello"}}
```

Default Content:

```handlebars
{{translate "Default"}}
```

```js
const messages = {
  "Hello": {
    'en': 'Hello',
    'fr': 'Salut',
    'es': 'Hola'
  },
  "Default": {
    'en': "The query didn't return any results.",
    'fr': "La requête n'a renvoyé aucun résultat.",
    'es': "La consulta no arrojó ningún resultado."
  },
}

const locale = getLocale();

handlebars.registerHelper('translate',
  (message) => messages[message][locale] ?? messages[message]['en']);
```