### PR TITLE
Add custom code option which is called after content is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features / Enhancements
 
 - Add ESLint deprecation check (#203)
+- Add custom code option which is called after content is ready (#231)
 
 ## 4.1.0 (2023-07-16)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marcusolsson-dynamictext-panel",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marcusolsson-dynamictext-panel",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.11.2",

--- a/src/components/Row/Row.tsx
+++ b/src/components/Row/Row.tsx
@@ -9,7 +9,7 @@ import { RowItem } from '../../types';
  */
 interface Props {
   /**
-   * Replace Variables
+   * Event Bus
    *
    * @type {EventBus}
    */
@@ -60,6 +60,7 @@ export const Row: React.FC<Props> = ({ className, item, afterRender, replaceVari
     let unsubscribe: unknown = null;
     if (ref.current && afterRender) {
       const func = new Function('context', afterRender);
+
       unsubscribe = func({
         element: ref.current,
         data: item.data,

--- a/src/components/Row/Row.tsx
+++ b/src/components/Row/Row.tsx
@@ -1,0 +1,89 @@
+import { EventBus, InterpolateFunction } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
+import React, { useEffect, useRef } from 'react';
+import { TestIds } from '../../constants';
+import { RowItem } from '../../types';
+
+/**
+ * Properties
+ */
+interface Props {
+  /**
+   * Replace Variables
+   *
+   * @type {EventBus}
+   */
+  eventBus: EventBus;
+
+  /**
+   * Replace Variables
+   *
+   * @type {InterpolateFunction}
+   */
+  replaceVariables: InterpolateFunction;
+
+  /**
+   * Item
+   *
+   * @type {RowItem}
+   */
+  item: RowItem;
+
+  /**
+   * Class Name
+   *
+   * @type {string}
+   */
+  className: string;
+
+  /**
+   * After Render Function
+   *
+   * @type {string}
+   */
+  afterRender: string;
+}
+
+/**
+ * Row
+ */
+export const Row: React.FC<Props> = ({ className, item, afterRender, replaceVariables, eventBus }) => {
+  /**
+   * Row Ref
+   */
+  const ref = useRef<HTMLDivElement>(null);
+
+  /**
+   * Run After Render Function
+   */
+  useEffect(() => {
+    let unsubscribe: unknown = null;
+    if (ref.current && afterRender) {
+      const func = new Function('context', afterRender);
+      unsubscribe = func({
+        element: ref.current,
+        data: item.data,
+        grafana: {
+          replaceVariables,
+          eventBus,
+          locationService,
+        },
+      });
+    }
+
+    return () => {
+      if (unsubscribe && typeof unsubscribe === 'function') {
+        unsubscribe();
+      }
+    };
+  }, [afterRender, eventBus, item.data, replaceVariables]);
+
+  return (
+    <div
+      ref={ref}
+      className={className}
+      dangerouslySetInnerHTML={{ __html: item.html }}
+      data-testid={TestIds.text.content}
+    />
+  );
+};

--- a/src/components/Row/index.ts
+++ b/src/components/Row/index.ts
@@ -1,0 +1,1 @@
+export * from './Row';

--- a/src/constants/default.ts
+++ b/src/constants/default.ts
@@ -15,4 +15,5 @@ export const DefaultOptions: PanelOptions = {
   helpers: '',
   status: '',
   styles: '',
+  afterRender: '',
 };

--- a/src/constants/default.ts
+++ b/src/constants/default.ts
@@ -5,6 +5,7 @@ import { CodeLanguage, Format } from './editor';
  * Default Options
  */
 export const DefaultOptions: PanelOptions = {
+  afterRender: '',
   content: '```json\n{{{json @root}}}\n```',
   defaultContent: "The query didn't return any results.",
   editor: { height: 200, format: Format.AUTO, language: CodeLanguage.MARKDOWN },
@@ -15,5 +16,4 @@ export const DefaultOptions: PanelOptions = {
   helpers: '',
   status: '',
   styles: '',
-  afterRender: '',
 };

--- a/src/constants/editor.ts
+++ b/src/constants/editor.ts
@@ -32,8 +32,8 @@ export enum Format {
  * Format Options
  */
 export const FormatOptions = [
-  { value: Format.AUTO, label: 'Auto' },
-  { value: Format.NONE, label: 'Disabled' },
+  { value: Format.AUTO, label: 'Auto', icon: 'font' },
+  { value: Format.NONE, label: 'Disabled', icon: 'times-circle' },
 ];
 
 /**

--- a/src/constants/panel.ts
+++ b/src/constants/panel.ts
@@ -15,4 +15,5 @@ export const EditorsOptions = [
   { value: EditorType.DEFAULT, label: 'Default Content' },
   { value: EditorType.HELPERS, label: 'JavaScript Code' },
   { value: EditorType.STYLES, label: 'Styles' },
+  { value: EditorType.AFTER_RENDER, label: 'JavaScript Code After Content Ready' },
 ];

--- a/src/constants/panel.ts
+++ b/src/constants/panel.ts
@@ -4,16 +4,16 @@ import { EditorType } from '../types';
  * Rows Options
  */
 export const EveryRowOptions = [
-  { value: true, label: 'Every row' },
-  { value: false, label: 'All rows' },
+  { value: true, label: 'Every row', icon: 'list-ul' },
+  { value: false, label: 'All rows', icon: 'book' },
 ];
 
 /**
  * Editors Options
  */
 export const EditorsOptions = [
-  { value: EditorType.DEFAULT, label: 'Default Content' },
-  { value: EditorType.HELPERS, label: 'JavaScript Code' },
+  { value: EditorType.DEFAULT, label: 'Default content' },
+  { value: EditorType.HELPERS, label: 'JavaScript code before content rendering' },
+  { value: EditorType.AFTER_RENDER, label: 'JavaScript code after content ready' },
   { value: EditorType.STYLES, label: 'Styles' },
-  { value: EditorType.AFTER_RENDER, label: 'JavaScript Code After Content Ready' },
 ];

--- a/src/module.ts
+++ b/src/module.ts
@@ -133,11 +133,23 @@ export const plugin = new PanelPlugin<PanelOptions>(TextPanel)
         id: 'helpers',
         path: 'helpers',
         name: 'JavaScript Code',
-        description: 'Allows to add Handlebars Helpers and event handlers.',
+        description: 'Allows to execute code before content rendering. E.g. add Handlebars Helpers.',
         defaultValue: DefaultOptions.helpers,
         editor: HelpersEditor,
         category: ['Content'],
         showIf: (config) => config.editors.includes(EditorType.HELPERS) || config.helpers !== DefaultOptions.helpers,
+      })
+      .addCustomEditor({
+        id: 'afterRender',
+        path: 'afterRender',
+        name: 'JavaScript Code After Content Ready',
+        description:
+          'Allows to execute code per item after content is ready. E.g. use element for drawing chart or event listeners.',
+        defaultValue: DefaultOptions.afterRender,
+        editor: HelpersEditor,
+        category: ['Content'],
+        showIf: (config) =>
+          config.editors.includes(EditorType.AFTER_RENDER) || config.afterRender !== DefaultOptions.afterRender,
       })
       .addCustomEditor({
         id: 'styles',

--- a/src/module.ts
+++ b/src/module.ts
@@ -128,39 +128,48 @@ export const plugin = new PanelPlugin<PanelOptions>(TextPanel)
         category: ['Content'],
         showIf: (config) =>
           config.editors.includes(EditorType.DEFAULT) || config.defaultContent !== DefaultOptions.defaultContent,
-      })
+      });
+
+    /**
+     * JavaScript
+     */
+    builder
       .addCustomEditor({
         id: 'helpers',
         path: 'helpers',
-        name: 'JavaScript Code',
+        name: 'Before Content Rendering',
         description: 'Allows to execute code before content rendering. E.g. add Handlebars Helpers.',
         defaultValue: DefaultOptions.helpers,
         editor: HelpersEditor,
-        category: ['Content'],
+        category: ['JavaScript'],
         showIf: (config) => config.editors.includes(EditorType.HELPERS) || config.helpers !== DefaultOptions.helpers,
       })
       .addCustomEditor({
         id: 'afterRender',
         path: 'afterRender',
-        name: 'JavaScript Code After Content Ready',
+        name: 'After Content Ready',
         description:
-          'Allows to execute code per item after content is ready. E.g. use element for drawing chart or event listeners.',
+          'Allows to execute code after content is ready. E.g. use element for drawing chart or event listeners.',
         defaultValue: DefaultOptions.afterRender,
         editor: HelpersEditor,
-        category: ['Content'],
+        category: ['JavaScript'],
         showIf: (config) =>
           config.editors.includes(EditorType.AFTER_RENDER) || config.afterRender !== DefaultOptions.afterRender,
-      })
-      .addCustomEditor({
-        id: 'styles',
-        path: 'styles',
-        name: 'CSS Styles',
-        description: 'Allows to add styles. Use & {} for parent style.',
-        defaultValue: DefaultOptions.styles,
-        editor: StylesEditor,
-        category: ['Content'],
-        showIf: (config) => config.editors.includes(EditorType.STYLES) || config.styles !== DefaultOptions.styles,
       });
+
+    /**
+     * Styles
+     */
+    builder.addCustomEditor({
+      id: 'styles',
+      path: 'styles',
+      name: 'CSS Styles',
+      description: 'Allows to add styles. Use & {} for parent style.',
+      defaultValue: DefaultOptions.styles,
+      editor: StylesEditor,
+      category: ['CSS Styles'],
+      showIf: (config) => config.editors.includes(EditorType.STYLES) || config.styles !== DefaultOptions.styles,
+    });
 
     return builder;
   });

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -1,5 +1,6 @@
 import { EditorOptions } from './editor';
 import { Resource } from './resource';
+import { DataFrame } from '@grafana/data';
 
 /**
  * Editor Types
@@ -8,6 +9,7 @@ export enum EditorType {
   DEFAULT = 'default',
   HELPERS = 'helpers',
   STYLES = 'styles',
+  AFTER_RENDER = 'afterRender',
 }
 
 /**
@@ -82,4 +84,30 @@ export interface PanelOptions {
    * @type {Resource[]}
    */
   externalScripts: Resource[];
+
+  /**
+   * After Render Function
+   *
+   * @type {string}
+   */
+  afterRender: string;
+}
+
+/**
+ * Row Item
+ */
+export interface RowItem {
+  /**
+   * HTML
+   *
+   * @type {string}
+   */
+  html: string;
+
+  /**
+   * Data
+   *
+   * @type {DataFrame | {}}
+   */
+  data: DataFrame | {};
 }

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -6,10 +6,10 @@ import { DataFrame } from '@grafana/data';
  * Editor Types
  */
 export enum EditorType {
+  AFTER_RENDER = 'afterRender',
   DEFAULT = 'default',
   HELPERS = 'helpers',
   STYLES = 'styles',
-  AFTER_RENDER = 'afterRender',
 }
 
 /**


### PR DESCRIPTION
Add a new custom code option (After Render Code) which is called for every row after row content was rendered. It's a good place to get access to DOM elements, draw charts and add event listeners.

Context object
```
element -> row DOM element
data -> row data
grafana: {
  replaceVariables,
  eventBus,
  locationService
}
```

Code example:
```
console.log(context);

return () => {
  console.log('destroy and unsubscribe');
}
```

Resolves #228 
Resolves #225 
Resolves #210 
Resolves #216
Resolves #223
Resolves #221 