### PR TITLE
Add option to enabled/disable wrapping to support empty lines in HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add ESLint deprecation check (#203)
 - Add custom code option which is called after content is ready (#231)
+- Add option to enabled/disable wrapping to support empty lines in HTML (#235)
 
 ## 4.1.0 (2023-07-16)
 

--- a/src/components/Text/Text.styles.ts
+++ b/src/components/Text/Text.styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { HighlightDark, HighlightLight } from './constants';
+import { HighlightDark, HighlightLight } from '../../constants';
 
 /**
  * Styles
@@ -65,13 +65,6 @@ export const Styles = (theme: GrafanaTheme2) => {
   const highlight = theme.isDark ? HighlightDark : HighlightLight;
 
   return {
-    root: css`
-      display: flex;
-      flex-direction: column;
-    `,
-    frameSelect: css`
-      padding: ${theme.spacing(1)};
-    `,
     frame,
     highlight,
   };

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -86,17 +86,21 @@ export const Text: React.FC<Props> = ({ options, frame, timeRange, timeZone, rep
    * HTML
    */
   const getHtml = useCallback(
-    (data: any, content: string) =>
-      generateHtml({
+    (data: any, content: string) => {
+      return {
+        ...generateHtml({
+          data,
+          content,
+          helpers: options.helpers,
+          timeRange,
+          timeZone,
+          replaceVariables,
+          eventBus,
+          options,
+        }),
         data,
-        content,
-        helpers: options.helpers,
-        timeRange,
-        timeZone,
-        replaceVariables,
-        eventBus,
-        options,
-      }),
+      };
+    },
     [eventBus, replaceVariables, timeRange, timeZone, options]
   );
 

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -86,8 +86,17 @@ export const Text: React.FC<Props> = ({ options, frame, timeRange, timeZone, rep
    */
   const getHtml = useCallback(
     (data: any, content: string) =>
-      generateHtml({ data, content, helpers: options.helpers, timeRange, timeZone, replaceVariables, eventBus }),
-    [eventBus, options.helpers, replaceVariables, timeRange, timeZone]
+      generateHtml({
+        data,
+        content,
+        helpers: options.helpers,
+        timeRange,
+        timeZone,
+        replaceVariables,
+        eventBus,
+        options,
+      }),
+    [eventBus, replaceVariables, timeRange, timeZone, options]
   );
 
   useEffect(() => {

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -5,7 +5,7 @@ import { TimeZone } from '@grafana/schema';
 import { Alert, useStyles2 } from '@grafana/ui';
 import { TestIds } from '../../constants';
 import { generateHtml } from '../../helpers';
-import { Styles } from '../../styles';
+import { Styles } from './Text.styles';
 import { PanelOptions, RowItem } from '../../types';
 import { Row } from '../Row';
 

--- a/src/components/TextPanel/TextPanel.styles.ts
+++ b/src/components/TextPanel/TextPanel.styles.ts
@@ -1,0 +1,17 @@
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+
+/**
+ * Styles
+ */
+export const Styles = (theme: GrafanaTheme2) => {
+  return {
+    root: css`
+      display: flex;
+      flex-direction: column;
+    `,
+    frameSelect: css`
+      padding: ${theme.spacing(1)};
+    `,
+  };
+};

--- a/src/components/TextPanel/TextPanel.tsx
+++ b/src/components/TextPanel/TextPanel.tsx
@@ -4,7 +4,7 @@ import { PanelProps, SelectableValue } from '@grafana/data';
 import { Select, useStyles2 } from '@grafana/ui';
 import { TestIds } from '../../constants';
 import { useExternalResources } from '../../hooks';
-import { Styles } from '../../styles';
+import { Styles } from './TextPanel.styles';
 import { PanelOptions, ResourceType } from '../../types';
 import { Text } from '../Text';
 

--- a/src/constants/default.ts
+++ b/src/constants/default.ts
@@ -15,4 +15,5 @@ export const DefaultOptions: PanelOptions = {
   helpers: '',
   status: '',
   styles: '',
+  wrap: true,
 };

--- a/src/constants/panel.ts
+++ b/src/constants/panel.ts
@@ -22,6 +22,6 @@ export const EditorsOptions = [
  * Wrap Options
  */
 export const WrapOptions = [
-  { value: true, label: 'Enabled' },
-  { value: false, label: 'Disabled' },
+  { value: true, label: 'Enabled', icon: 'file-copy-alt' },
+  { value: false, label: 'Disabled', icon: 'times-circle' },
 ];

--- a/src/constants/panel.ts
+++ b/src/constants/panel.ts
@@ -16,3 +16,11 @@ export const EditorsOptions = [
   { value: EditorType.HELPERS, label: 'JavaScript Code' },
   { value: EditorType.STYLES, label: 'Styles' },
 ];
+
+/**
+ * Wrap Options
+ */
+export const WrapOptions = [
+  { value: true, label: 'Enabled' },
+  { value: false, label: 'Disabled' },
+];

--- a/src/helpers/html.ts
+++ b/src/helpers/html.ts
@@ -6,6 +6,7 @@ import { config, locationService } from '@grafana/runtime';
 import { TimeZone } from '@grafana/schema';
 import { registerHelpers } from './handlebars';
 import { replaceVariablesHelper } from './variable';
+import { PanelOptions } from '../types';
 
 /**
  * Helpers
@@ -23,6 +24,7 @@ export const generateHtml = ({
   timeZone,
   replaceVariables,
   eventBus,
+  options,
 }: {
   data: Record<string, any>;
   content: string;
@@ -31,6 +33,7 @@ export const generateHtml = ({
   timeZone: TimeZone;
   replaceVariables: InterpolateFunction;
   eventBus: EventBus;
+  options: PanelOptions;
 }): { html: string; unsubscribe?: unknown } => {
   /**
    * Variable
@@ -93,7 +96,7 @@ export const generateHtml = ({
   /**
    * Render Markdown
    */
-  const html = md.render(markdown);
+  const html = options.wrap ? md.render(markdown) : md.renderInline(markdown);
 
   /**
    * Skip sanitizing if disabled in Grafana

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,14 @@
 import { Field, FieldConfigProperty, FieldType, PanelPlugin } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { HelpersEditor, ResourcesEditor, StylesEditor, TextEditor, TextPanel } from './components';
-import { CodeLanguageOptions, DefaultOptions, EditorsOptions, EveryRowOptions, FormatOptions } from './constants';
+import {
+  CodeLanguageOptions,
+  DefaultOptions,
+  EditorsOptions,
+  EveryRowOptions,
+  FormatOptions,
+  WrapOptions,
+} from './constants';
 import { EditorType, PanelOptions } from './types';
 
 /**
@@ -110,6 +117,16 @@ export const plugin = new PanelPlugin<PanelOptions>(TextPanel)
      * Content
      */
     builder
+      .addRadio({
+        path: 'wrap',
+        name: 'Wrap automatically in paragraphs',
+        description: 'If disabled, result will NOT be wrapped into <p> tags',
+        defaultValue: DefaultOptions.wrap,
+        settings: {
+          options: WrapOptions,
+        },
+        category: ['Content'],
+      })
       .addCustomEditor({
         id: 'content',
         path: 'content',

--- a/src/module.ts
+++ b/src/module.ts
@@ -120,7 +120,7 @@ export const plugin = new PanelPlugin<PanelOptions>(TextPanel)
       .addRadio({
         path: 'wrap',
         name: 'Wrap automatically in paragraphs',
-        description: 'If disabled, result will NOT be wrapped into <p> tags',
+        description: 'If disabled, result will NOT be wrapped into <p> tags.',
         defaultValue: DefaultOptions.wrap,
         settings: {
           options: WrapOptions,

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -82,4 +82,11 @@ export interface PanelOptions {
    * @type {Resource[]}
    */
   externalScripts: Resource[];
+
+  /**
+   * Wrap
+   *
+   * @type {boolean}
+   */
+  wrap: boolean;
 }


### PR DESCRIPTION
Resolves #222 

Content
```
<figure class=" rounded-xl ">
  <ul class="w-96  rounded-full border-1">
    <li class="h-px my-4 border-0 animate-pulse  ">
      Not Started : 235
    </li>

    <li class="h-px my-8 bg-stone-600 border-0 dark:bg-gray-700">
      In Progress : 300
    </li>

    <li class="h-px my-8 bg-stone-600 border-0 dark:bg-gray-700">
      Completed : 100
    </li>

  </ul>
</figure>
```

Result with wrap
<img width="751" alt="Screenshot 2023-11-15 at 17 17 13" src="https://github.com/VolkovLabs/volkovlabs-dynamictext-panel/assets/15867703/8237c5e0-756d-4f4f-8b3c-e9b63788272a">

Result with no wrap
<img width="767" alt="Screenshot 2023-11-15 at 17 17 18" src="https://github.com/VolkovLabs/volkovlabs-dynamictext-panel/assets/15867703/c5392b1a-bc54-42f1-9ff3-2b0c24b3a397">

