### PR TITLE
Add data render mode and passing selected data frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update ESLint configuration and refactor (#239)
 - Update Collapse from @volkovlabs/components (#239)
 - Update Introduction video in README (#240)
+- Add data render mode and passing selected data frame (#246)
 
 ### Bug fixes
 

--- a/src/components/Row/Row.tsx
+++ b/src/components/Row/Row.tsx
@@ -65,6 +65,7 @@ export const Row: React.FC<Props> = ({ className, item, afterRender, replaceVari
       unsubscribe = func({
         element: ref.current,
         data: item.data,
+        panelData: item.panelData,
         grafana: {
           replaceVariables,
           eventBus,
@@ -78,7 +79,7 @@ export const Row: React.FC<Props> = ({ className, item, afterRender, replaceVari
         unsubscribe();
       }
     };
-  }, [afterRender, eventBus, item.data, replaceVariables]);
+  }, [afterRender, eventBus, item.data, item.panelData, replaceVariables]);
 
   return (
     <div

--- a/src/components/Text/Text.test.tsx
+++ b/src/components/Text/Text.test.tsx
@@ -9,12 +9,13 @@ import { Props, Text } from './Text';
 /**
  * Text
  */
-describe('<Text />', () => {
+describe('Text', () => {
   /**
    * Default Content
    */
   it('Should render default content when there is no dataframe', async () => {
     const props: Props = {
+      data: {} as any,
       options: {
         ...DEFAULT_OPTIONS,
         content: 'Test content',
@@ -39,6 +40,7 @@ describe('<Text />', () => {
     `;
     const replaceVariables = jest.fn((str: string) => str);
     const props: Props = {
+      data: {} as any,
       options: {
         ...DEFAULT_OPTIONS,
         content: 'Test content',
@@ -68,6 +70,7 @@ describe('<Text />', () => {
       const replaceVariables = jest.fn((str: string) => str);
 
       const props: Props = {
+        data: {} as any,
         options: {
           ...DEFAULT_OPTIONS,
           defaultContent: '<div id="element"></div>',
@@ -94,6 +97,7 @@ describe('<Text />', () => {
       const replaceVariables = jest.fn((str: string) => str);
 
       const props: Props = {
+        data: {} as any,
         options: {
           ...DEFAULT_OPTIONS,
           defaultContent: '<div id="element"></div>',
@@ -132,6 +136,7 @@ describe('<Text />', () => {
       ],
     });
     const props: Props = {
+      data: {} as any,
       frame: dataFrame,
       options: {
         ...DEFAULT_OPTIONS,
@@ -154,12 +159,13 @@ describe('<Text />', () => {
   });
 
   /**
-   * Render content twice
+   * Render every row
    */
-  it('Should render content twice when there is a dataframe and everyRow is true', async () => {
+  it('Should render content twice when there is a dataframe and every row enabled', async () => {
     const nameData: string[] = ['Erik', 'Natasha'];
     const ageData: number[] = [42, 38];
     const props: Props = {
+      data: {} as any,
       frame: toDataFrame({
         fields: [
           {
@@ -197,10 +203,11 @@ describe('<Text />', () => {
   });
 
   /**
-   * Render content once
+   * Render all rows
    */
-  it('Should render content once when there is a dataframe and everyRow is false', async () => {
+  it('Should render content once when there is a dataframe and all rows enabled', async () => {
     const props: Props = {
+      data: {} as any,
       frame: {
         fields: [],
         length: 2,
@@ -210,6 +217,45 @@ describe('<Text />', () => {
         content: 'Test content',
         defaultContent: 'Test default content',
         renderMode: RenderMode.ALL_ROWS,
+      },
+      timeRange: {} as any,
+      timeZone: '',
+      replaceVariables: (str: string) => str,
+      eventBus: {} as any,
+    };
+
+    render(<Text {...props} />);
+
+    expect(screen.getAllByText('Test content')).toHaveLength(1);
+  });
+
+  /**
+   * Render all data
+   */
+  it('Should render content once when there is a dataframe and all data enabled', async () => {
+    const props: Props = {
+      data: {
+        series: [
+          toDataFrame({
+            fields: [
+              {
+                type: FieldType.string,
+                name: 'text',
+                values: ['hello', 'hello2'],
+              },
+            ],
+          }),
+        ],
+      } as any,
+      frame: {
+        fields: [],
+        length: 2,
+      },
+      options: {
+        ...DEFAULT_OPTIONS,
+        content: 'Test content',
+        defaultContent: 'Test default content',
+        renderMode: RenderMode.DATA,
       },
       timeRange: {} as any,
       timeZone: '',
@@ -237,6 +283,7 @@ describe('<Text />', () => {
 `;
 
     const props: Props = {
+      data: {} as any,
       frame: toDataFrame({
         fields: [
           {
@@ -259,6 +306,67 @@ describe('<Text />', () => {
         content: template,
         defaultContent: 'Test default content',
         renderMode: RenderMode.ALL_ROWS,
+      },
+      timeRange: {} as any,
+      timeZone: '',
+      replaceVariables: (str: string) => str,
+      eventBus: {} as any,
+    };
+
+    render(<Text {...props} />);
+
+    expect(screen.getAllByRole('row')[1]).toHaveTextContent('Erik');
+    expect(screen.getAllByRole('row')[2]).toHaveTextContent('Natasha');
+  });
+
+  /**
+   * Render all data properties
+   */
+  it('Should render properties of all panel data in template', async () => {
+    const nameData: string[] = ['Erik', 'Natasha'];
+    const ageData: number[] = [42, 38];
+
+    const template = `| Name | Age |
+| ---- | --- |
+{{#each data.[0]}}
+{{name}} - {{#with (lookup ../data.[1] @index)}}{{age}}{{/with}}
+{{/each}}
+`;
+
+    const frames = [
+      toDataFrame({
+        fields: [
+          {
+            name: 'name',
+            type: FieldType.string,
+            config: {},
+            values: nameData,
+          },
+        ],
+        length: 2,
+      }),
+      toDataFrame({
+        fields: [
+          {
+            name: 'age',
+            type: FieldType.number,
+            config: {},
+            values: ageData,
+          },
+        ],
+        length: 2,
+      }),
+    ];
+    const props: Props = {
+      data: {
+        series: frames,
+      } as any,
+      frame: frames[0],
+      options: {
+        ...DEFAULT_OPTIONS,
+        content: template,
+        defaultContent: 'Test default content',
+        renderMode: RenderMode.DATA,
       },
       timeRange: {} as any,
       timeZone: '',

--- a/src/components/Text/Text.test.tsx
+++ b/src/components/Text/Text.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { DEFAULT_OPTIONS, TEST_IDS } from '../../constants';
+import { RenderMode } from '../../types';
 import { Props, Text } from './Text';
 
 /**
@@ -18,7 +19,7 @@ describe('<Text />', () => {
         ...DEFAULT_OPTIONS,
         content: 'Test content',
         defaultContent: 'Test default content',
-        everyRow: true,
+        renderMode: RenderMode.ALL_ROWS,
       },
       timeRange: {} as any,
       timeZone: '',
@@ -42,7 +43,7 @@ describe('<Text />', () => {
         ...DEFAULT_OPTIONS,
         content: 'Test content',
         defaultContent: 'Test default content',
-        everyRow: true,
+        renderMode: RenderMode.EVERY_ROW,
         styles,
       },
       timeRange: {} as any,
@@ -73,7 +74,7 @@ describe('<Text />', () => {
           afterRender: `
           context.grafana.eventBus.publish('ready', context.element.querySelector('#element'));
           `,
-          everyRow: true,
+          renderMode: RenderMode.EVERY_ROW,
         },
         timeRange: {} as any,
         timeZone: '',
@@ -99,7 +100,7 @@ describe('<Text />', () => {
           afterRender: `
           return () => context.grafana.eventBus.publish('destroy');
           `,
-          everyRow: true,
+          renderMode: RenderMode.EVERY_ROW,
         },
         timeRange: {} as any,
         timeZone: '',
@@ -137,7 +138,7 @@ describe('<Text />', () => {
         status: 'value',
         content: '<div style="background-color: {{statusColor}};" data-testid="status">{{status}}</div>',
         defaultContent: 'Test default content',
-        everyRow: true,
+        renderMode: RenderMode.EVERY_ROW,
       },
       timeRange: {} as any,
       timeZone: '',
@@ -179,7 +180,7 @@ describe('<Text />', () => {
         ...DEFAULT_OPTIONS,
         content: 'Test content',
         defaultContent: 'Test default content',
-        everyRow: true,
+        renderMode: RenderMode.EVERY_ROW,
       },
       timeRange: {} as any,
       timeZone: '',
@@ -208,7 +209,7 @@ describe('<Text />', () => {
         ...DEFAULT_OPTIONS,
         content: 'Test content',
         defaultContent: 'Test default content',
-        everyRow: false,
+        renderMode: RenderMode.ALL_ROWS,
       },
       timeRange: {} as any,
       timeZone: '',
@@ -257,7 +258,7 @@ describe('<Text />', () => {
         ...DEFAULT_OPTIONS,
         content: template,
         defaultContent: 'Test default content',
-        everyRow: false,
+        renderMode: RenderMode.ALL_ROWS,
       },
       timeRange: {} as any,
       timeZone: '',

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -67,7 +67,15 @@ export interface Props {
 /**
  * Text
  */
-export const Text: React.FC<Props> = ({ options, frame, timeRange, timeZone, replaceVariables, eventBus, data }) => {
+export const Text: React.FC<Props> = ({
+  options,
+  frame,
+  timeRange,
+  timeZone,
+  replaceVariables,
+  eventBus,
+  data: panelData,
+}) => {
   /**
    * Generated rows
    */
@@ -94,10 +102,10 @@ export const Text: React.FC<Props> = ({ options, frame, timeRange, timeZone, rep
    * HTML
    */
   const getHtml = useCallback(
-    (data: Record<string, unknown>, content: string) => {
+    (htmlData: Record<string, unknown>, content: string) => {
       return {
         ...generateHtml({
-          data,
+          data: htmlData,
           content,
           helpers: options.helpers,
           timeRange,
@@ -105,11 +113,12 @@ export const Text: React.FC<Props> = ({ options, frame, timeRange, timeZone, rep
           replaceVariables,
           eventBus,
           options,
+          panelData,
         }),
-        data,
+        data: htmlData,
       };
     },
-    [eventBus, replaceVariables, timeRange, timeZone, options]
+    [options, timeRange, timeZone, replaceVariables, eventBus, panelData]
   );
 
   useEffect(() => {
@@ -131,6 +140,7 @@ export const Text: React.FC<Props> = ({ options, frame, timeRange, timeZone, rep
           {
             html,
             data: {},
+            panelData,
           },
         ]);
         unsubscribeFn = unsubscribe;
@@ -138,7 +148,7 @@ export const Text: React.FC<Props> = ({ options, frame, timeRange, timeZone, rep
         /**
          * Frame returned
          */
-        const frames = options.renderMode === RenderMode.DATA ? data.series : [frame];
+        const frames = options.renderMode === RenderMode.DATA ? panelData.series : [frame];
         const templateData = frames.map((frame) =>
           frame.fields.reduce(
             (acc, { config, name, values, display }) => {
@@ -169,6 +179,7 @@ export const Text: React.FC<Props> = ({ options, frame, timeRange, timeZone, rep
             rows.map(({ html, data }) => ({
               html,
               data,
+              panelData,
             }))
           );
 
@@ -188,7 +199,7 @@ export const Text: React.FC<Props> = ({ options, frame, timeRange, timeZone, rep
            */
           const data = options.renderMode === RenderMode.DATA ? templateData : templateData[0];
           const { html, unsubscribe } = getHtml({ data }, options.content);
-          setRows([{ html, data }]);
+          setRows([{ html, data, panelData }]);
 
           unsubscribeFn = unsubscribe;
         }
@@ -203,7 +214,6 @@ export const Text: React.FC<Props> = ({ options, frame, timeRange, timeZone, rep
       }
     };
   }, [
-    data.series,
     frame,
     frame?.fields,
     frame?.length,
@@ -212,6 +222,7 @@ export const Text: React.FC<Props> = ({ options, frame, timeRange, timeZone, rep
     options.defaultContent,
     options.renderMode,
     options.status,
+    panelData,
   ]);
 
   if (error) {

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -114,11 +114,12 @@ export const Text: React.FC<Props> = ({
           eventBus,
           options,
           panelData,
+          dataFrame: frame,
         }),
         data: htmlData,
       };
     },
-    [options, timeRange, timeZone, replaceVariables, eventBus, panelData]
+    [options, timeRange, timeZone, replaceVariables, eventBus, panelData, frame]
   );
 
   useEffect(() => {
@@ -141,6 +142,7 @@ export const Text: React.FC<Props> = ({
             html,
             data: {},
             panelData,
+            dataFrame: frame,
           },
         ]);
         unsubscribeFn = unsubscribe;
@@ -180,6 +182,7 @@ export const Text: React.FC<Props> = ({
               html,
               data,
               panelData,
+              dataFrame: frame,
             }))
           );
 
@@ -199,7 +202,7 @@ export const Text: React.FC<Props> = ({
            */
           const data = options.renderMode === RenderMode.DATA ? templateData : templateData[0];
           const { html, unsubscribe } = getHtml({ data }, options.content);
-          setRows([{ html, data, panelData }]);
+          setRows([{ html, data, panelData, dataFrame: frame }]);
 
           unsubscribeFn = unsubscribe;
         }

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { TEST_IDS } from '../../constants';
 import { generateHtml } from '../../helpers';
-import { PanelOptions, RowItem } from '../../types';
+import { PanelOptions, RenderMode, RowItem } from '../../types';
 import { Row } from '../Row';
 import { getStyles } from './Text.styles';
 
@@ -150,7 +150,7 @@ export const Text: React.FC<Props> = ({ options, frame, timeRange, timeZone, rep
           [] as Array<Record<string, unknown>>
         );
 
-        if (options.everyRow) {
+        if (options.renderMode === RenderMode.EVERY_ROW) {
           /**
            * For every row in data frame
            */
@@ -197,7 +197,7 @@ export const Text: React.FC<Props> = ({ options, frame, timeRange, timeZone, rep
     getHtml,
     options.content,
     options.defaultContent,
-    options.everyRow,
+    options.renderMode,
     options.status,
   ]);
 

--- a/src/components/TextPanel/TextPanel.test.tsx
+++ b/src/components/TextPanel/TextPanel.test.tsx
@@ -107,7 +107,11 @@ describe('Panel', () => {
 
   it('Should find component', async () => {
     render(
-      getComponent({ options: { ...defaultOptions, defaultContent: 'hello' }, replaceVariables: (str: string) => str })
+      getComponent({
+        options: { ...defaultOptions, defaultContent: 'hello' },
+        replaceVariables: (str: string) => str,
+        data: { series: [] } as any,
+      })
     );
 
     expect(screen.getByTestId(TEST_IDS.panel.root)).toBeInTheDocument();

--- a/src/components/TextPanel/TextPanel.test.tsx
+++ b/src/components/TextPanel/TextPanel.test.tsx
@@ -2,8 +2,14 @@ import { FieldType, toDataFrame } from '@grafana/data';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { TEST_IDS } from '../../constants';
+import { CodeLanguage, Format, TEST_IDS } from '../../constants';
+import { PanelOptions, RenderMode } from '../../types';
 import { TextPanel } from './TextPanel';
+
+/**
+ * Props
+ */
+type Props = React.ComponentProps<typeof TextPanel>;
 
 /**
  * Mock @grafana/runtime
@@ -57,7 +63,33 @@ jest.mock('../../hooks', () => ({
  * Panel
  */
 describe('Panel', () => {
-  const getComponent = ({ options = { name: 'data' }, ...restProps }: any) => {
+  /**
+   * Default options
+   */
+  const defaultOptions: PanelOptions = {
+    content: '',
+    defaultContent: '',
+    renderMode: RenderMode.ALL_ROWS,
+    editors: [],
+    helpers: '',
+    editor: {
+      height: 300,
+      format: Format.AUTO,
+      language: CodeLanguage.JAVASCRIPT,
+    },
+    styles: '',
+    status: '',
+    externalScripts: [],
+    externalStyles: [],
+    wrap: false,
+    afterRender: '',
+  };
+
+  /**
+   * Get Component
+   * @param props
+   */
+  const getComponent = ({ options = defaultOptions, ...restProps }: Partial<Props>) => {
     const data = {
       series: [
         toDataFrame({
@@ -66,7 +98,7 @@ describe('Panel', () => {
         }),
       ],
     };
-    return <TextPanel data={data} {...restProps} options={options} />;
+    return <TextPanel data={data} options={options} {...(restProps as any)} />;
   };
 
   afterAll(() => {
@@ -74,7 +106,9 @@ describe('Panel', () => {
   });
 
   it('Should find component', async () => {
-    render(getComponent({ options: { defaultContent: 'hello' }, replaceVariables: (str: string) => str }));
+    render(
+      getComponent({ options: { ...defaultOptions, defaultContent: 'hello' }, replaceVariables: (str: string) => str })
+    );
 
     expect(screen.getByTestId(TEST_IDS.panel.root)).toBeInTheDocument();
   });
@@ -85,7 +119,7 @@ describe('Panel', () => {
       unsubscribe,
     }));
 
-    const eventBus = {
+    const eventBus: any = {
       subscribe,
     };
 
@@ -106,6 +140,7 @@ describe('Panel', () => {
       render(
         getComponent({
           options: {
+            ...defaultOptions,
             defaultContent: 'hello',
             helpers,
           },
@@ -130,6 +165,7 @@ describe('Panel', () => {
       const { rerender } = render(
         getComponent({
           options: {
+            ...defaultOptions,
             defaultContent: 'hello',
             helpers,
           },
@@ -146,6 +182,7 @@ describe('Panel', () => {
       rerender(
         getComponent({
           options: {
+            ...defaultOptions,
             defaultContent: 'hello',
             helpers,
           },
@@ -162,7 +199,7 @@ describe('Panel', () => {
 
     it('Should call unsubscribe function for every row', () => {
       const values = ['111', '222'];
-      const data = {
+      const data: any = {
         series: [
           toDataFrame({
             name: 'data',
@@ -179,9 +216,10 @@ describe('Panel', () => {
       const { rerender } = render(
         getComponent({
           options: {
+            ...defaultOptions,
             content: 'hello',
             helpers,
-            everyRow: true,
+            renderMode: RenderMode.EVERY_ROW,
           },
           replaceVariables: (str: string) => str,
           data,
@@ -198,9 +236,10 @@ describe('Panel', () => {
       rerender(
         getComponent({
           options: {
+            ...defaultOptions,
             content: 'hello',
             helpers,
-            everyRow: true,
+            renderMode: RenderMode.EVERY_ROW,
           },
           replaceVariables: (str: string) => str,
           data,
@@ -216,7 +255,7 @@ describe('Panel', () => {
 
     it('Should call unsubscribe function for data frame', () => {
       const values = ['111', '222'];
-      const data = {
+      const data: any = {
         series: [
           toDataFrame({
             name: 'data',
@@ -233,9 +272,10 @@ describe('Panel', () => {
       const { rerender } = render(
         getComponent({
           options: {
+            ...defaultOptions,
             content: 'hello',
             helpers,
-            everyRow: false,
+            renderMode: RenderMode.ALL_ROWS,
           },
           replaceVariables: (str: string) => str,
           data,
@@ -252,9 +292,10 @@ describe('Panel', () => {
       rerender(
         getComponent({
           options: {
+            ...defaultOptions,
             content: 'hello',
             helpers,
-            everyRow: false,
+            renderMode: RenderMode.EVERY_ROW,
           },
           replaceVariables: (str: string) => str,
           data,
@@ -275,6 +316,7 @@ describe('Panel', () => {
       const { rerender } = render(
         getComponent({
           options: {
+            ...defaultOptions,
             defaultContent: 'hello',
             helpers: `abc()`,
           },
@@ -296,6 +338,7 @@ describe('Panel', () => {
       rerender(
         getComponent({
           options: {
+            ...defaultOptions,
             defaultContent: 'hello',
             helpers,
           },
@@ -322,6 +365,7 @@ describe('Panel', () => {
       render(
         getComponent({
           options: {
+            ...defaultOptions,
             defaultContent: 'hello',
             helpers: `throw 'abc'`,
           },
@@ -343,7 +387,7 @@ describe('Panel', () => {
     it('Should show field frame if frames are several', () => {
       render(
         getComponent({
-          options: { defaultContent: 'hello' },
+          options: { ...defaultOptions, defaultContent: 'hello' },
           replaceVariables: (str: string) => str,
           data: {
             series: [
@@ -354,7 +398,7 @@ describe('Panel', () => {
                 refId: 'B',
               },
             ],
-          },
+          } as any,
         })
       );
 
@@ -366,7 +410,7 @@ describe('Panel', () => {
     it('Should change frame', () => {
       render(
         getComponent({
-          options: { defaultContent: 'hello' },
+          options: { ...defaultOptions, defaultContent: 'hello' },
           replaceVariables: (str: string) => str,
           data: {
             series: [
@@ -377,7 +421,7 @@ describe('Panel', () => {
                 refId: 'B',
               },
             ],
-          },
+          } as any,
         })
       );
 

--- a/src/components/TextPanel/TextPanel.tsx
+++ b/src/components/TextPanel/TextPanel.tsx
@@ -5,7 +5,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 
 import { TEST_IDS } from '../../constants';
 import { useExternalResources } from '../../hooks';
-import { PanelOptions, ResourceType } from '../../types';
+import { PanelOptions, RenderMode, ResourceType } from '../../types';
 import { Text } from '../Text';
 import { getStyles } from './TextPanel.styles';
 
@@ -113,10 +113,11 @@ export const TextPanel: React.FC<Props> = ({
               timeZone={timeZone}
               replaceVariables={replaceVariables}
               eventBus={eventBus}
+              data={data}
             />
           </div>
 
-          {data.series.length > 1 && (
+          {options.renderMode !== RenderMode.DATA && data.series.length > 1 && (
             <div className={styles.frameSelect}>
               <Select
                 onChange={onChangeFrame}

--- a/src/components/TextPanel/TextPanel.tsx
+++ b/src/components/TextPanel/TextPanel.tsx
@@ -63,7 +63,7 @@ export const TextPanel: React.FC<Props> = ({
   /**
    * Selected Frame
    */
-  const frame = data.series[frameIndex];
+  const frame = data.series[frameIndex] ? data.series[frameIndex] : undefined;
 
   /**
    * External Scripts
@@ -121,7 +121,7 @@ export const TextPanel: React.FC<Props> = ({
             <div className={styles.frameSelect}>
               <Select
                 onChange={onChangeFrame}
-                value={frame.refId}
+                value={frame?.refId}
                 options={selectableFrames}
                 data-testid={TEST_IDS.panel.fieldFrame}
               />

--- a/src/constants/default.ts
+++ b/src/constants/default.ts
@@ -1,4 +1,4 @@
-import { PanelOptions } from '../types';
+import { PanelOptions, RenderMode } from '../types';
 import { CodeLanguage, Format } from './editor';
 
 /**
@@ -10,7 +10,7 @@ export const DEFAULT_OPTIONS: PanelOptions = {
   defaultContent: "The query didn't return any results.",
   editor: { height: 200, format: Format.AUTO, language: CodeLanguage.MARKDOWN },
   editors: [],
-  everyRow: true,
+  renderMode: RenderMode.EVERY_ROW,
   externalScripts: [],
   externalStyles: [],
   helpers: '',

--- a/src/constants/panel.ts
+++ b/src/constants/panel.ts
@@ -1,11 +1,11 @@
-import { EditorType } from '../types';
+import { EditorType, RenderMode } from '../types';
 
 /**
- * Rows Options
+ * Render Mode Options
  */
-export const EVERY_ROW_OPTIONS = [
-  { value: true, label: 'Every row', icon: 'list-ul' },
-  { value: false, label: 'All rows', icon: 'book' },
+export const RENDER_MODE_OPTIONS = [
+  { value: RenderMode.EVERY_ROW, label: 'Every row', icon: 'list-ul' },
+  { value: RenderMode.ALL_ROWS, label: 'All rows', icon: 'book' },
 ];
 
 /**

--- a/src/constants/panel.ts
+++ b/src/constants/panel.ts
@@ -6,6 +6,7 @@ import { EditorType, RenderMode } from '../types';
 export const RENDER_MODE_OPTIONS = [
   { value: RenderMode.EVERY_ROW, label: 'Every row', icon: 'list-ul' },
   { value: RenderMode.ALL_ROWS, label: 'All rows', icon: 'book' },
+  { value: RenderMode.DATA, label: 'All data', icon: 'gf-layout-simple' },
 ];
 
 /**

--- a/src/helpers/html.ts
+++ b/src/helpers/html.ts
@@ -1,4 +1,4 @@
-import { EventBus, getLocale, InterpolateFunction, PanelData, textUtil, TimeRange } from '@grafana/data';
+import { DataFrame, EventBus, getLocale, InterpolateFunction, PanelData, textUtil, TimeRange } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 import { TimeZone } from '@grafana/schema';
 import Handlebars from 'handlebars';
@@ -27,6 +27,7 @@ export const generateHtml = ({
   eventBus,
   options,
   panelData,
+  dataFrame,
 }: {
   data: Record<string, unknown>;
   content: string;
@@ -37,6 +38,7 @@ export const generateHtml = ({
   eventBus: EventBus;
   options: PanelOptions;
   panelData: PanelData;
+  dataFrame?: DataFrame;
 }): { html: string; unsubscribe?: unknown } => {
   /**
    * Variable
@@ -62,6 +64,7 @@ export const generateHtml = ({
       'locationService',
       'eventBus',
       'panelData',
+      'dataFrame',
       helpers
     );
     unsubscribe = func(
@@ -74,6 +77,7 @@ export const generateHtml = ({
       locationService,
       eventBus,
       panelData,
+      dataFrame,
       helpers
     );
   }

--- a/src/helpers/html.ts
+++ b/src/helpers/html.ts
@@ -1,4 +1,4 @@
-import { EventBus, getLocale, InterpolateFunction, textUtil, TimeRange } from '@grafana/data';
+import { EventBus, getLocale, InterpolateFunction, PanelData, textUtil, TimeRange } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 import { TimeZone } from '@grafana/schema';
 import Handlebars from 'handlebars';
@@ -26,6 +26,7 @@ export const generateHtml = ({
   replaceVariables,
   eventBus,
   options,
+  panelData,
 }: {
   data: Record<string, unknown>;
   content: string;
@@ -35,6 +36,7 @@ export const generateHtml = ({
   replaceVariables: InterpolateFunction;
   eventBus: EventBus;
   options: PanelOptions;
+  panelData: PanelData;
 }): { html: string; unsubscribe?: unknown } => {
   /**
    * Variable
@@ -59,6 +61,7 @@ export const generateHtml = ({
       'replaceVariables',
       'locationService',
       'eventBus',
+      'panelData',
       helpers
     );
     unsubscribe = func(
@@ -70,6 +73,7 @@ export const generateHtml = ({
       replaceVariables,
       locationService,
       eventBus,
+      panelData,
       helpers
     );
   }

--- a/src/migration.test.ts
+++ b/src/migration.test.ts
@@ -1,0 +1,17 @@
+import { getMigratedOptions } from './migration';
+import { RenderMode } from './types';
+
+describe('Migration', () => {
+  describe('4.3.0', () => {
+    it('Should normalize everyRow', () => {
+      expect(getMigratedOptions({ options: { everyRow: true } } as any)).toHaveProperty(
+        'renderMode',
+        RenderMode.EVERY_ROW
+      );
+      expect(getMigratedOptions({ options: { everyRow: false } } as any)).toHaveProperty(
+        'renderMode',
+        RenderMode.ALL_ROWS
+      );
+    });
+  });
+});

--- a/src/migration.test.ts
+++ b/src/migration.test.ts
@@ -1,7 +1,19 @@
 import { getMigratedOptions } from './migration';
-import { RenderMode } from './types';
+import { PanelOptions, RenderMode } from './types';
 
 describe('Migration', () => {
+  it('Should return panel options', () => {
+    const options: Partial<PanelOptions> = {
+      renderMode: RenderMode.EVERY_ROW,
+    };
+
+    expect(
+      getMigratedOptions({
+        options: options as any,
+      } as any)
+    ).toEqual(options);
+  });
+
   describe('4.3.0', () => {
     it('Should normalize everyRow', () => {
       expect(getMigratedOptions({ options: { everyRow: true } } as any)).toHaveProperty(

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -1,0 +1,35 @@
+import { PanelModel } from '@grafana/data';
+
+import { PanelOptions, RenderMode } from './types';
+
+/**
+ * Outdated Panel Options
+ *
+ * Removed in *version*
+ */
+interface OutdatedPanelOptions {
+  /**
+   * 4.3.0
+   */
+  everyRow?: boolean;
+}
+
+/**
+ * Get Migrated Options
+ * @param panel
+ */
+export const getMigratedOptions = (panel: PanelModel<OutdatedPanelOptions & PanelOptions>): PanelOptions => {
+  const { everyRow, ...actualOptions } = panel.options;
+
+  /**
+   * Normalize every row
+   */
+  if (everyRow !== undefined) {
+    return {
+      ...actualOptions,
+      renderMode: panel.options.everyRow ? RenderMode.EVERY_ROW : RenderMode.ALL_ROWS,
+    };
+  }
+
+  return actualOptions;
+};

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -4,12 +4,12 @@ import { PanelOptions, RenderMode } from './types';
 
 /**
  * Outdated Panel Options
- *
- * Removed in *version*
  */
 interface OutdatedPanelOptions {
   /**
-   * 4.3.0
+   * Every row
+   *
+   * Removed in 4.3.0
    */
   everyRow?: boolean;
 }
@@ -27,9 +27,11 @@ export const getMigratedOptions = (panel: PanelModel<OutdatedPanelOptions & Pane
   if (everyRow !== undefined) {
     return {
       ...actualOptions,
-      renderMode: panel.options.everyRow ? RenderMode.EVERY_ROW : RenderMode.ALL_ROWS,
+      renderMode: everyRow ? RenderMode.EVERY_ROW : RenderMode.ALL_ROWS,
     };
   }
 
-  return actualOptions;
+  return {
+    ...actualOptions,
+  };
 };

--- a/src/module.test.ts
+++ b/src/module.test.ts
@@ -23,6 +23,7 @@ describe('plugin', () => {
     addRadio: jest.fn().mockImplementation(() => builder),
     addSliderInput: jest.fn().mockImplementation(() => builder),
     addMultiSelect: jest.fn().mockImplementation(() => builder),
+    addSelect: jest.fn().mockImplementation(() => builder),
   };
 
   it('Should be instance of PanelPlugin', () => {

--- a/src/module.ts
+++ b/src/module.ts
@@ -34,7 +34,7 @@ export const plugin = new PanelPlugin<PanelOptions>(TextPanel)
   })
   .setPanelOptions((builder) => {
     builder
-      .addRadio({
+      .addSelect({
         path: 'renderMode',
         name: 'Render template',
         settings: {

--- a/src/module.ts
+++ b/src/module.ts
@@ -6,10 +6,11 @@ import {
   CODE_LANGUAGE_OPTIONS,
   DEFAULT_OPTIONS,
   EDITORS_OPTIONS,
-  EVERY_ROW_OPTIONS,
   FORMAT_OPTIONS,
+  RENDER_MODE_OPTIONS,
   WRAP_OPTIONS,
 } from './constants';
+import { getMigratedOptions } from './migration';
 import { EditorType, PanelOptions } from './types';
 
 /**
@@ -17,6 +18,7 @@ import { EditorType, PanelOptions } from './types';
  */
 export const plugin = new PanelPlugin<PanelOptions>(TextPanel)
   .setNoPadding()
+  .setMigrationHandler(getMigratedOptions)
   .useFieldConfig({
     disableStandardOptions: [
       FieldConfigProperty.Unit,
@@ -33,12 +35,12 @@ export const plugin = new PanelPlugin<PanelOptions>(TextPanel)
   .setPanelOptions((builder) => {
     builder
       .addRadio({
-        path: 'everyRow',
+        path: 'renderMode',
         name: 'Render template',
         settings: {
-          options: EVERY_ROW_OPTIONS,
+          options: RENDER_MODE_OPTIONS,
         },
-        defaultValue: DEFAULT_OPTIONS.everyRow,
+        defaultValue: DEFAULT_OPTIONS.renderMode,
       })
       .addMultiSelect({
         path: 'editors',

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -134,4 +134,11 @@ export interface RowItem {
    * @type {PanelData}
    */
   panelData: PanelData;
+
+  /**
+   * Selected Data Frame
+   *
+   * @type {DataFrame}
+   */
+  dataFrame?: DataFrame;
 }

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -14,6 +14,14 @@ export enum EditorType {
 }
 
 /**
+ * Render Mode
+ */
+export enum RenderMode {
+  EVERY_ROW = 'everyRow',
+  ALL_ROWS = 'allRow',
+}
+
+/**
  * Panel Options
  */
 export interface PanelOptions {
@@ -32,11 +40,11 @@ export interface PanelOptions {
   defaultContent: string;
 
   /**
-   * Every Row
+   * Render Mode
    *
-   * @type {boolean}
+   * @type {RenderMode}
    */
-  everyRow: boolean;
+  renderMode: RenderMode;
 
   /**
    * Editors to Display

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -18,7 +18,8 @@ export enum EditorType {
  */
 export enum RenderMode {
   EVERY_ROW = 'everyRow',
-  ALL_ROWS = 'allRow',
+  ALL_ROWS = 'allRows',
+  DATA = 'data',
 }
 
 /**

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -1,4 +1,4 @@
-import { DataFrame } from '@grafana/data';
+import { DataFrame, PanelData } from '@grafana/data';
 
 import { EditorOptions } from './editor';
 import { Resource } from './resource';
@@ -127,4 +127,11 @@ export interface RowItem {
    * @type {DataFrame | object}
    */
   data: DataFrame | object;
+
+  /**
+   * Panel Data
+   *
+   * @type {PanelData}
+   */
+  panelData: PanelData;
 }


### PR DESCRIPTION
Resolves #243 
Resolves #247 

Example of iteration within panel data:

Data
```
{ data: [[{ name: 'a' }, { name: 'b' }], [{ age: 10 }, { age: 20 }] ] }
```

Template
```
{{#each data.[0]}}
{{name}} - {{#with (lookup ../data.[1] @index)}}{{age}}{{/with}}
{{/each}}
```