### PR TITLE
Disable unitScale and fieldMinMax standard panel options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.4.0 (IN PROGRESS)
+## 4.4.0 (2024-03-06)
 
 ### Features / Enhancements
 
@@ -10,6 +10,7 @@
 - Replace custom code parameters with Code Parameters Builder (#285)
 - Update CSS class for the Panel instead of a Row (#272)
 - Update Editor auto height from fixed value (#278)
+- Disable unitScale and fieldMinMax standard panel options (#286)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 4.4.0 (2024-03-06)
 
+### Breaking changes
+
+- Requires Grafana 9.2 and Grafana 10
+
 ### Features / Enhancements
 
 - Update context parameter (#270)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Dynamic Text Panel plugin allows you to construct a text visualization templ
 
 ## Requirements
 
-- Dynamic Text Panel 4.X requires **Grafana 9** or **Grafana 10**.
+- Dynamic Text Panel 4.X requires **Grafana 9.2** or **Grafana 10**.
 - Dynamic Text Panel 2.X and 3.X require **Grafana 8.5** or **Grafana 9**.
 - Dynamic Text Panel 1.X requires **Grafana 7**.
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -30,6 +30,8 @@ export const plugin = new PanelPlugin<PanelOptions>(TextPanel)
       FieldConfigProperty.NoValue,
       FieldConfigProperty.Links,
       FieldConfigProperty.Mappings,
+      'unitScale' as never,
+      'fieldMinMax' as never,
     ],
   })
   .setPanelOptions((builder) => {

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://github.com/grafana/grafana/raw/main/docs/sources/developers/plugins/plugin.schema.json",
   "dependencies": {
-    "grafanaDependency": ">=9.0.0",
+    "grafanaDependency": ">=9.2.0",
     "plugins": []
   },
   "id": "marcusolsson-dynamictext-panel",


### PR DESCRIPTION
New standard panel options appeared in Grafana 10.3.X.